### PR TITLE
Configure Tide to skip non-required status contexts

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- smrtrfszm
+- TwoDCube

--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -94,6 +94,9 @@ data:
     tide:
       merge_method:
         Verseghy: squash
+      context_options:
+        from-branch-protection: true
+        skip-unknown-contexts: true
       queries:
       - labels:
         - lgtm


### PR DESCRIPTION
## Summary
- Add `context_options` under `tide` with `from-branch-protection: true` and `skip-unknown-contexts: true`
- Tide will now only block merges on contexts that are marked required by GitHub branch protection, ignoring other/unknown checks (e.g. https://github.com/Verseghy/iam/pull/135)

## Test plan
- [ ] Apply config and confirm Tide re-evaluates open PRs (e.g. Verseghy/iam#135) and merges when required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)