### PR TITLE
Limit branchprotector scope to master branches

### DIFF
--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -110,6 +110,8 @@ data:
         - Verseghy
 
     branch-protection:
+      include:
+      - "^master$"
       protect: true
       enforce_admins: true
       allow_force_pushes: false


### PR DESCRIPTION
## Summary
- Add \`include: ["^master$"]\` to \`branch-protection\` so branchprotector only applies to the default branch of each Verseghy repo instead of cascading to every feature/dependabot/renovate branch.

## Test plan
- [ ] After rollout, branchprotector run only emits GetBranchProtection/UpdateBranchProtection calls for \`master\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)