### PR TITLE
Unmanage secure (private) repo in branchprotector

### DIFF
--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -123,6 +123,8 @@ data:
       orgs:
         Verseghy:
           repos:
+            secure:
+              unmanaged: true
             iam:
               branches:
                 master:


### PR DESCRIPTION
## Summary
- Add \`unmanaged: true\` for \`Verseghy/secure\` so branchprotector doesn't try to fetch/update its branch protection (requires GitHub Pro for private repos) and abort the whole run with 403.

## Test plan
- [ ] Next branchprotector run completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)