### PR TITLE
Point Tide status context at Deck tide dashboard

### DIFF
--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -92,6 +92,7 @@ data:
             sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260128-95b2a3412
 
     tide:
+      target_url: https://prow.apps.okd4.home.zoltanszepesi.com/tide
       merge_method:
         Verseghy: squash
       context_options:


### PR DESCRIPTION
## Summary
- Add \`tide.target_url\` so the 'tide' status check on PRs links to \`/tide\` on Deck, matching the upstream Prow UX.

## Test plan
- [ ] After rollout and Tide's next status-update sync, clicking the 'tide' status on an open PR opens the Deck merge pool page

🤖 Generated with [Claude Code](https://claude.com/claude-code)