### PR TITLE
Point Tide status link at per-PR Deck /pr query

### DIFF
--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -92,7 +92,8 @@ data:
             sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260128-95b2a3412
 
     tide:
-      target_url: https://prow.apps.okd4.home.zoltanszepesi.com/tide
+      pr_status_base_urls:
+        "*": https://prow.apps.okd4.home.zoltanszepesi.com/pr
       merge_method:
         Verseghy: squash
       context_options:


### PR DESCRIPTION
## Summary
- Replace \`tide.target_url\` with \`tide.pr_status_base_urls\` so the 'tide' status context on each PR links to \`/pr?query=is:pr+repo:...+author:...+head:...\` (the per-PR view on Deck) instead of the global \`/tide\` page.

## Test plan
- [ ] On a freshly re-stamped tide status (new commit / state change), clicking 'tide' opens the Deck /pr page filtered to that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)