### PR TITLE
Enable GitHub OAuth on Deck

### DIFF
--- a/verseghy-website/eso-in-cluster/prow-externalsecrets.yaml
+++ b/verseghy-website/eso-in-cluster/prow-externalsecrets.yaml
@@ -55,6 +55,52 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
+  name: github-oauth-config
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: SecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+    template:
+      data:
+        secret: |
+          client_id: {{ .client_id }}
+          client_secret: {{ .client_secret }}
+          redirect_url: https://prow.apps.okd4.home.zoltanszepesi.com/github-login/redirect
+          final_redirect_url: https://prow.apps.okd4.home.zoltanszepesi.com/
+          scopes:
+          - user:email
+          - read:org
+          - repo
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: prow-github-oauth-config/client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: prow-github-oauth-config/client_secret
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cookie-secret
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: SecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+    - secretKey: secret
+      remoteRef:
+        key: prow-cookie-secret/secret
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
   name: s3-credentials
 spec:
   refreshInterval: 24h

--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -339,6 +339,9 @@ spec:
             - --spyglass=true
             - --github-app-id=$(GITHUB_APP_ID)
             - --github-app-private-key-path=/etc/github/cert
+            - --oauth-url=/github-login
+            - --github-oauth-config-file=/etc/githuboauth/secret
+            - --cookie-secret=/etc/cookie/secret
           env:
             - name: GITHUB_APP_ID
               valueFrom:
@@ -360,6 +363,12 @@ spec:
               readOnly: true
             - name: s3-credentials
               mountPath: /etc/s3-credentials
+              readOnly: true
+            - name: github-oauth-config
+              mountPath: /etc/githuboauth
+              readOnly: true
+            - name: cookie-secret
+              mountPath: /etc/cookie
               readOnly: true
           livenessProbe:
             httpGet:
@@ -387,6 +396,12 @@ spec:
         - name: s3-credentials
           secret:
             secretName: s3-credentials
+        - name: github-oauth-config
+          secret:
+            secretName: github-oauth-config
+        - name: cookie-secret
+          secret:
+            secretName: cookie-secret
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- Two new ExternalSecrets (\`github-oauth-config\`, \`cookie-secret\`) pulling from 1Password
- Deck deployment gains OAuth flags + secret volume mounts
- Unblocks the per-PR \`/pr?query=...\` link that Tide now stamps on status contexts

## Test plan
- [ ] Secrets materialize in \`verseghy\` namespace
- [ ] Deck restarts cleanly with new args
- [ ] \`POST /pr-data.js\` returns 200 once logged in via GitHub OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)