### PR TITLE
Require tide status check to block UI merges

### DIFF
--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -122,6 +122,8 @@ data:
       required_conversation_resolution: true
       required_status_checks:
         strict: false
+        contexts:
+        - tide
       orgs:
         Verseghy:
           repos:


### PR DESCRIPTION
## Summary
- Add \`tide\` to the global \`required_status_checks.contexts\` so every managed repo requires the tide context to be green before the GitHub UI allows a merge.

## Test plan
- [ ] After branchprotector reconcile, the merge button on iam#137 is disabled pending tide
- [ ] Tide itself can still merge via the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)