### PR TITLE
Bump label_sync to v20260325-0ac3b4d79f

### DIFF
--- a/verseghy-website/prow/prow.yaml
+++ b/verseghy-website/prow/prow.yaml
@@ -943,7 +943,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: label-sync
-              image: gcr.io/k8s-staging-test-infra/label_sync:v20240731-a5d9345e59
+              image: gcr.io/k8s-staging-test-infra/label_sync:v20260325-0ac3b4d79f
               args:
                 - --config=/etc/config/labels.yaml
                 - --confirm=true


### PR DESCRIPTION
## Summary
- Point the label-sync CronJob at the current staging image tag so the first scheduled run (and manual triggers) stop ImagePullBackOff-ing.

## Test plan
- [ ] Manual \`oc create job --from=cronjob/label-sync\` succeeds and flips lgtm/approved to green across Verseghy repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)