### PR TITLE
Auto-trigger Shipwright builds on master push (Pipelines-as-Code)

### DIFF
--- a/verseghy-website/builds/README.md
+++ b/verseghy-website/builds/README.md
@@ -1,0 +1,50 @@
+# Automatic image builds (Pipelines-as-Code → Shipwright)
+
+The Shipwright `Build` objects in this directory (`frontend`, `backend2`) define
+*how* the images are built. This README documents how they are **triggered
+automatically on every push to `master`**, instead of being kicked off by hand.
+
+## How it works
+
+```
+git push master ──▶ GitHub App (PAC, app-id 1271459)
+                        │  webhook
+                        ▼
+        pipelines-as-code-controller (openshift-pipelines)
+                        │  matches event URL to a Repository CR
+                        ▼
+        Repository CR (this dir) ── routes into namespace `verseghy`
+                        │  reads .tekton/push.yaml from the pushed commit
+                        ▼
+        PipelineRun (build-frontend / build-backend2)
+                        │  oc create buildrun + poll
+                        ▼
+        Shipwright BuildRun ──▶ pushes ghcr.io/verseghy/<image>
+```
+
+Two pieces are needed per repository:
+
+| Piece | Lives in | File |
+|-------|----------|------|
+| `Repository` CR (opt-in + namespace routing) | this repo (GitOps) | `pac-repository-frontend.yaml`, `pac-repository-backend2.yaml` |
+| `PipelineRun` trigger (`.tekton/`) | the **source** repo's `master` branch | `website_frontend/.tekton/push.yaml`, `website_backend2/.tekton/push.yaml` |
+
+The PipelineRun does not rebuild the image itself; it creates a Shipwright
+`BuildRun` for the existing `Build` and waits for it, so the result is reported
+back onto the commit as a GitHub check.
+
+## Notes / caveats
+
+- **Revision:** the Shipwright `Build` pins no git revision, so a `BuildRun`
+  always builds current `master` HEAD. For a push event that is the triggering
+  commit; the SHA is recorded as a label (`pipelinesascode.tekton.dev/sha`) for
+  traceability. Rapid back-to-back pushes may both build the newer HEAD —
+  `concurrency_limit: 1` on the Repository serializes them.
+- **Auth:** uses the cluster-global PAC GitHub App; no per-repo secret needed.
+  The App must be **installed on each source repo** in the GitHub org for events
+  to flow.
+- **RBAC:** the PipelineRun runs as the `pipeline` ServiceAccount in `verseghy`,
+  which already has `create/get` on `buildruns.shipwright.io` via the
+  `openshift-pipelines-edit` (ClusterRole/edit) binding.
+- **PR builds (optional):** to also build on pull requests, add a
+  `.tekton/pull-request.yaml` with `on-event: "[pull_request]"`.

--- a/verseghy-website/builds/pac-repository-backend2.yaml
+++ b/verseghy-website/builds/pac-repository-backend2.yaml
@@ -1,0 +1,20 @@
+# Pipelines-as-Code Repository binding for the website backend2.
+#
+# This CR opts the GitHub repository into PAC and routes its events into the
+# `verseghy` namespace. Authentication is handled by the cluster-global PAC
+# GitHub App (app-id 1271459 in openshift-pipelines/pipelines-as-code-secret),
+# so no per-repo provider secret is required here.
+#
+# When a `push` event for this repo arrives, PAC reads `.tekton/push.yaml` from
+# the pushed revision and runs it as a PipelineRun in this namespace. See that
+# file (in the website_backend2 repo) for the actual build trigger logic.
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: website-backend2
+  namespace: verseghy
+spec:
+  url: https://github.com/Verseghy/website_backend2
+  # Serialize PipelineRuns for this repo so two rapid master pushes don't kick
+  # off competing image builds; the latest queued run wins.
+  concurrency_limit: 1

--- a/verseghy-website/builds/pac-repository-frontend.yaml
+++ b/verseghy-website/builds/pac-repository-frontend.yaml
@@ -1,0 +1,20 @@
+# Pipelines-as-Code Repository binding for the website frontend.
+#
+# This CR opts the GitHub repository into PAC and routes its events into the
+# `verseghy` namespace. Authentication is handled by the cluster-global PAC
+# GitHub App (app-id 1271459 in openshift-pipelines/pipelines-as-code-secret),
+# so no per-repo provider secret is required here.
+#
+# When a `push` event for this repo arrives, PAC reads `.tekton/push.yaml` from
+# the pushed revision and runs it as a PipelineRun in this namespace. See that
+# file (in the website_frontend repo) for the actual build trigger logic.
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: website-frontend
+  namespace: verseghy
+spec:
+  url: https://github.com/Verseghy/website_frontend
+  # Serialize PipelineRuns for this repo so two rapid master pushes don't kick
+  # off competing image builds; the latest queued run wins.
+  concurrency_limit: 1


### PR DESCRIPTION
## What

Registers the **frontend** and **backend2** source repos with Pipelines-as-Code (PAC) so a push to `master` automatically triggers their existing Shipwright `Build`s — no more manual `BuildRun`s.

## Files

- `verseghy-website/builds/pac-repository-frontend.yaml` / `pac-repository-backend2.yaml` — PAC `Repository` CRs that opt each repo in and route its events into the `verseghy` namespace.
- `verseghy-website/builds/README.md` — documents the PAC → Shipwright trigger flow.

These are picked up by the existing `verseghy-website-builds` ArgoCD Application (synced from `verseghy-website/builds/`).

## How it works

`git push master` → PAC GitHub App webhook → `pipelines-as-code-controller` matches the event to the `Repository` CR → reads `.tekton/push.yaml` from the pushed commit → runs a `PipelineRun` in `verseghy` that creates a Shipwright `BuildRun` and waits for it (so pass/fail is reported back as a GitHub check).

## Dependencies

- Companion PRs add `.tekton/push.yaml` to each source repo:
  - `Verseghy/website_frontend` → `pac-build-trigger`
  - `Verseghy/website_backend2` → `pac-build-trigger`
- The cluster-global PAC GitHub App (`app-id 1271459`) must be **installed on both source repos**.

## Validation

- All manifests pass `yq` parse and `oc apply --dry-run=server` against the live cluster.
- Auth: cluster-global PAC GitHub App (no per-repo secret). RBAC: the `pipeline` SA in `verseghy` already has `create/get buildruns.shipwright.io` via `ClusterRole/edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)